### PR TITLE
Erro ao gerar o mesmo relatório mais de uma vez: java.lang.IllegalSta…

### DIFF
--- a/src/main/java/lab/cliente/controller/ClienteController.java
+++ b/src/main/java/lab/cliente/controller/ClienteController.java
@@ -90,12 +90,18 @@ public class ClienteController {
     }
 
     @RequestMapping(path = "/report/clientes", method = RequestMethod.GET)
-    public ModelAndView reportClientes(@RequestParam(value = "acao", required = false) String acao,
+    public ModelAndView reportClientes() {
+        ModelAndView view = new ModelAndView("/cliente/view.cliente.report");
+        HashMap fileType = ReportUtils.tipoArquivo();
+        view.addObject("filetype", fileType);
+        return view;
+    }
+
+    @RequestMapping(path = "/report/clientes", method = RequestMethod.POST)
+    public void reportClientes(@RequestParam(value = "acao", required = false) String acao,
             @RequestParam(value = "tipoArquivo", required = false) String tipoArquivo,
             HttpServletResponse response) {
-
-        ModelAndView view = new ModelAndView("/cliente/view.cliente.report");
-        try {
+        try{
             if (StringUtils.isNotBlank(acao)
                     && StringUtils.isNotBlank(tipoArquivo)) {
                 String realPath = ReportUtils.contextPath(context);
@@ -108,9 +114,5 @@ public class ClienteController {
         } catch (SQLException | JRException | IOException e) {
             Logger.getLogger(ClienteController.class.getName()).log(Level.SEVERE, null, e);
         }
-
-        HashMap fileType = ReportUtils.tipoArquivo();
-        view.addObject("filetype", fileType);
-        return view;
     }
 }

--- a/src/main/webapp/cliente/view.cliente.report.jsp
+++ b/src/main/webapp/cliente/view.cliente.report.jsp
@@ -16,7 +16,7 @@
             </div>
             <div class="row">
                 <div class="col-md-12">
-                    <form method="get">
+                    <form method="post">
                         <select name="tipoArquivo">
                             <c:forEach items="${filetype}" var="filetype">
                             <option value="${filetype.key}">${filetype.value}</option>


### PR DESCRIPTION
…teException

Ao gerar o relatório, ao redirecionar a página pra ela mesmo era gerada uma excessão `java.lang.IllegalStateException: getOutputStream() has already been called for this response.` por causa que o `response` já estava aberto.

Fixed #4